### PR TITLE
Unified errors and documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ carthage update RxHttpClient
 Commands above are necessary if Carthage trying to build RxHttpClient before RxSwift.
 
 ##Usage
-###StreamData
+####StreamData
 For create request and streaming data:
 ```
 let client = HttpClient()
@@ -41,7 +41,7 @@ client.loadStreamData(url).bindNext { event in
 }.addDisposableTo(bag)
 ```
 
-If dealing with every chunk of data is not necessary it's possible to pass an instance of cache provider and in success event crab all data from that provider (for now there is only MemoryCacheProvider object):
+If dealing with every chunk of data is not necessary it's possible to pass an instance of cache provider and in success event grab all data from that provider (for now there is only MemoryCacheProvider object):
 ```
 let client = HttpClient()
 let bag = DisposeBag()
@@ -56,7 +56,7 @@ client.loadStreamData(url, cacheProvider: MemoryCacheProvider()).bindNext { even
 }.addDisposableTo(bag)
 ```
 
-###Convenience methods
+####Convenience methods
 It's also possible to simply invoke request and receive data using loadData method (in this case errors are forwarded with RxSwift error mechanism):
 ```
 let client = HttpClient()
@@ -84,7 +84,7 @@ let request = client.createUrlRequest(url, headers: ["Header": "Value"])
 client.loadData(request).bindNext { data in /* */ }.addDisposableTo(bag)
 ```
 
-###StreamDataTask
+####StreamDataTask
 StreamDataTask is a more "low level" object that wraps NSURLSessionDataTask. In most situations is't more convenient to use loadStreamData method (it actually simply forwards events from StreamDataTask), but if necessary StreamDataTask may be used in this way:
 ```
 let client = HttpClient()

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,115 @@
+RxHttpClient
+----
+[![Build Status](https://travis-ci.org/reloni/RxHttpClient.svg?branch=master)](https://travis-ci.org/reloni/RxHttpClient)
+[![codecov](https://codecov.io/gh/reloni/RxHttpClient/branch/master/graph/badge.svg)](https://codecov.io/gh/reloni/RxHttpClient)
+![Platform iOS](https://img.shields.io/badge/platform-iOS-lightgray.svg)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+
+RxHttpClient is a "reactive wrapper" around NSURLSession. Under the hood it implements session delegates (like NSURLSessionDelegate or NSURLSessionTaskDelegate) and translates session events into Observables using [RxSwift](https://github.com/ReactiveX/RxSwift). Main purpose of this framework is to make "streaming" data as simple as possible and provide convenient features for caching data.
+
+Now it is more than a preliminary version and it lacking functionality and may be unstable in some cases.
+
+##Installation
+Now only [Carthage](https://github.com/Carthage/Carthage) supported:
+```
+github "ReactiveX/RxSwift" ~> 2.6
+github "Reloni/RxHttpClient"
+```
+RxHttpClient uses RxSwift so it should be included into cartfile.
+
+```
+carthage update RxSwift
+carthage update RxHttpClient
+```
+Commands above are necessary if Carthage trying to build RxHttpClient before RxSwift.
+
+##Usage
+###StreamData
+For create request and streaming data:
+```
+let client = HttpClient()
+let bag = DisposeBag()
+let url = NSURL(string: "url_to_resource")!
+client.loadStreamData(url).bindNext { event in
+  switch event {
+  case StreamTaskEvents.ReceiveResponse(let response): /* Occurs after receiving response from remote server */
+  case StreamTaskEvents.ReceiveData(let data): /* Occurs after receiving chunk of data from server (generally occurred many times) */
+  case StreamTaskEvents.Error(let error): /* Occurs in case of client-side error */
+  case StreamTaskEvents.Success: /* Occurs after successful completion of request */
+  default: break
+  }
+}.addDisposableTo(bag)
+```
+
+If dealing with every chunk of data is not necessary it's possible to pass an instance of cache provider and in success event crab all data from that provider (for now there is only MemoryCacheProvider object):
+```
+let client = HttpClient()
+let bag = DisposeBag()
+let url = NSURL(string: "url_to_resource")!
+client.loadStreamData(url, cacheProvider: MemoryCacheProvider()).bindNext { event in
+  if case StreamTaskEvents.Success(let cacheProvider) = event {
+    if let cacheProvider = cacheProvider {
+      // getting cached data from provider
+      let downloadedData = cacheProvider.getCurrentData()
+    }
+  }
+}.addDisposableTo(bag)
+```
+
+###Convenience methods
+It's also possible to simply invoke request and receive data using loadData method (in this case errors are forwarded with RxSwift error mechanism):
+```
+let client = HttpClient()
+let bag = DisposeBag()
+let url = NSURL(string: "url_to_resource")!
+client.loadData(url)
+  .doOnError { error in
+    switch error {
+    case HttpClientError.ClientSideError(let error): /* Client-side error /*
+    case let HttpClientError.InvalidResponse(response, data): /* Occurs when server did't return success HTTP code (not in 2xx) */
+    default: break
+    }
+  }
+  .bindNext { data in
+  // do something with returned data
+}.addDisposableTo(bag)
+```
+
+Creating url request with additional HTTP headers:
+```
+let client = HttpClient()
+let bag = DisposeBag()
+let url = NSURL(string: "url_to_resource")!
+let request = client.createUrlRequest(url, headers: ["Header": "Value"])
+client.loadData(request).bindNext { data in /* */ }.addDisposableTo(bag)
+```
+
+###StreamDataTask
+StreamDataTask is a more "low level" object that wraps NSURLSessionDataTask. In most situations is't more convenient to use loadStreamData method (it actually simply forwards events from StreamDataTask), but if necessary StreamDataTask may be used in this way:
+```
+let client = HttpClient()
+let bag = DisposeBag()
+let url = NSURL(string: "url_to_resource")!
+let request = client.createUrlRequest(url, headers: ["Header": "Value"])
+let task = client.createStreamDataTask(request, cacheProvider: nil)
+// represents same events as loadStreamData method
+task.taskProgress.bindNext { event in
+  switch event {
+  case StreamTaskEvents.ReceiveResponse(let response): /* Occurs after receiving response from remote server */
+  case StreamTaskEvents.ReceiveData(let data): /* Occurs after receiving chunk of data from server (generally occurred many times) */
+  case StreamTaskEvents.Error(let error): /* Occurs in case of client-side error */
+  case StreamTaskEvents.Success: /* Occurs after successful completion of request */
+  default: break
+  }
+}.addDisposableTo(bag)
+
+// resume task
+task.resume()
+```
+
+##How it works
+HttpClient object holds it's own NSURLSession. It creates session by providing a session delegate object for handling session-related events. So StreamTaskEvents enum actually represents this session events, for example `case ReceiveResponse(NSURLResponse)` means that `URLSession(_:dataTask:didReceiveResponse:completionHandler:)` delegate method was invoked.
+Because NSURLSession holds strong reference to delegate it should be invalidated, HttpClient do that in deinitializer by invoking finishTasksAndInvalidate() method, so session will allow running tasks to finish work.
+
+## Contributing
+For contributing please check out **develop** branch and also target it in pull request.

--- a/RxHttpClient.xcodeproj/project.pbxproj
+++ b/RxHttpClient.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		6EFB9EF81D2A5BC300E30A5D /* NSURLSessionDataEventsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFB9ED71D2A53FD00E30A5D /* NSURLSessionDataEventsObserver.swift */; };
 		6EFB9EF91D2A5BC300E30A5D /* StreamDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFB9ED81D2A53FD00E30A5D /* StreamDataTask.swift */; };
 		6EFB9EFE1D2A5C8E00E30A5D /* Fake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFB9EF01D2A587100E30A5D /* Fake.swift */; };
+		6EFE01CE1D5A5E1E007CE72A /* HttpClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFE01CD1D5A5E1E007CE72A /* HttpClientError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +63,7 @@
 		6EFB9EEA1D2A57B600E30A5D /* MemoryCacheProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MemoryCacheProviderTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6EFB9EEB1D2A57B600E30A5D /* StreamDataTaskTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = StreamDataTaskTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		6EFB9EF01D2A587100E30A5D /* Fake.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Fake.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		6EFE01CD1D5A5E1E007CE72A /* HttpClientError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HttpClientError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +108,7 @@
 		6EFB9EBA1D2A4E2600E30A5D /* RxHttpClient */ = {
 			isa = PBXGroup;
 			children = (
+				6EFE01CD1D5A5E1E007CE72A /* HttpClientError.swift */,
 				6EFB9ED31D2A53FD00E30A5D /* HttpClientType.swift */,
 				6E1C07C11D48FF92009513FD /* HttpClientType+Extensions.swift */,
 				6E81B0371D4A850100D099F1 /* HttpClient.swift */,
@@ -269,6 +272,7 @@
 				6EFB9EF91D2A5BC300E30A5D /* StreamDataTask.swift in Sources */,
 				6EFB9EE61D2A563000E30A5D /* MimeTypeConverter.swift in Sources */,
 				6E81B0381D4A850100D099F1 /* HttpClient.swift in Sources */,
+				6EFE01CE1D5A5E1E007CE72A /* HttpClientError.swift in Sources */,
 				6EFB9EF41D2A5BBF00E30A5D /* CacheProviderType.swift in Sources */,
 				6EFB9EF51D2A5BC300E30A5D /* HttpClientType.swift in Sources */,
 				6E81B03A1D4A85CF00D099F1 /* MemoryCacheProvider.swift in Sources */,

--- a/RxHttpClient/HttpClient.swift
+++ b/RxHttpClient/HttpClient.swift
@@ -68,6 +68,6 @@ extension HttpClient : HttpClientType {
 	*/
 	public func createStreamDataTask(taskUid: String, request: NSURLRequest, cacheProvider: CacheProviderType?) -> StreamDataTaskType {
 		let dataTask = urlSession.dataTaskWithRequest(request)
-		return StreamDataTask(taskUid: taskUid, dataTask: dataTask, httpClient: self, sessionEvents: sessionObserver.sessionEvents, cacheProvider: cacheProvider)
+		return StreamDataTask(taskUid: taskUid, dataTask: dataTask, sessionEvents: sessionObserver.sessionEvents, cacheProvider: cacheProvider)
 	}
 }

--- a/RxHttpClient/HttpClientError.swift
+++ b/RxHttpClient/HttpClientError.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Represents an error
+public enum HttpClientError : ErrorType {
+	/**
+	This error occurred if remote server returned response with unsuccessful HTTP status code (not in 2xx SUCCESS)
+	- parameter response: HTTP response returned by server
+	- parameter data: Data returned by server
+	*/
+	case InvalidResponse(response: NSHTTPURLResponse, data: NSData?)
+	/**
+	This error occured when underlying NSURLSession was explicitly invalidated (by finishTasksAndInvalidate() or invalidateAndCancel() methods)
+	*/
+	case SessionExplicitlyInvalidated
+	/**
+	This error occorred if underlying NSURLSession was invalidated with specific error
+	- parameter error: The error that caused invalidation
+	*/
+	case SessionInvalidatedWithError(error: NSError)
+}

--- a/RxHttpClient/HttpClientError.swift
+++ b/RxHttpClient/HttpClientError.swift
@@ -1,20 +1,24 @@
 import Foundation
 
-/// Represents an error
+/// Represents an error.
 public enum HttpClientError : ErrorType {
 	/**
-	This error occurred if remote server returned response with unsuccessful HTTP status code (not in 2xx SUCCESS)
-	- parameter response: HTTP response returned by server
-	- parameter data: Data returned by server
+	This error occurred if remote server returned response with unsuccessful HTTP status code (not in 2xx SUCCESS).
+	- parameter response: HTTP response returned by server.
+	- parameter data: Data returned by server.
 	*/
 	case InvalidResponse(response: NSHTTPURLResponse, data: NSData?)
 	/**
-	This error occured when underlying NSURLSession was explicitly invalidated (by finishTasksAndInvalidate() or invalidateAndCancel() methods)
+	This error occured when underlying NSURLSession was explicitly invalidated (by finishTasksAndInvalidate() or invalidateAndCancel() methods).
 	*/
 	case SessionExplicitlyInvalidated
 	/**
-	This error occorred if underlying NSURLSession was invalidated with specific error
-	- parameter error: The error that caused invalidation
+	This error occorred if underlying NSURLSession was invalidated with specific error.
+	- parameter error: The error that caused invalidation.
 	*/
 	case SessionInvalidatedWithError(error: NSError)
+	/**
+	This error represents client-side error (such as being unable to resolve the hostname or connect to the host).
+	*/
+	case ClientSideError(error: NSError)
 }

--- a/RxHttpClient/HttpClientType+Extensions.swift
+++ b/RxHttpClient/HttpClientType+Extensions.swift
@@ -66,9 +66,16 @@ public extension HttpClientType {
 		return loadStreamData(request, cacheProvider: cacheProvider)
 			.flatMapLatest { result -> Observable<NSData> in
 				switch result {
-				case .Error(let error): return Observable.error(error)
-					// checking status code of HTTP responce, and caching response if code is not success
+				case .Error(let error):
+					// checking error type
+					guard error is HttpClientError else {
+						// if it's not HttpClientError wrap it on ClientSideError
+						return Observable.error(HttpClientError.ClientSideError(error: error as NSError))
+					}
+					// otherwise forward error
+					return Observable.error(error)
 				case .ReceiveResponse(let response as NSHTTPURLResponse) where !(200...299 ~= response.statusCode):
+					// checking status code of HTTP responce, and caching response if code is not success (not 2xx)
 					// saving response
 					errorResponse = response
 					return Observable.empty()

--- a/RxHttpClient/HttpClientType+Extensions.swift
+++ b/RxHttpClient/HttpClientType+Extensions.swift
@@ -1,10 +1,6 @@
 import Foundation
 import RxSwift
 
-public enum HttpRequestError : ErrorType {
-	case Unsuccessful(NSURLResponse, NSData?)
-}
-
 public extension HttpClientType {
 	/**
 	Creates NSMutableURLRequest with provided NSURL and HTTP Headers
@@ -82,7 +78,7 @@ public extension HttpClientType {
 						return Observable.just(cacheProvider.getCurrentData())
 					}
 					
-					return Observable.error(HttpRequestError.Unsuccessful(errorResponse, cacheProvider.getCurrentData()))
+					return Observable.error(HttpClientError.InvalidResponse(response: errorResponse, data: cacheProvider.getCurrentData()))
 				default: return Observable.empty()
 				}
 		}

--- a/RxHttpClient/MemoryCacheProvider.swift
+++ b/RxHttpClient/MemoryCacheProvider.swift
@@ -5,7 +5,7 @@ public final class MemoryCacheProvider {
 	public var expectedDataLength: Int64 = 0
 	
 	/// MIME type of cached data
-	public var contentMimeType: String?
+	public internal(set) var contentMimeType: String?
 	
 	/// UID of cache provider
 	public let uid: String
@@ -16,9 +16,13 @@ public final class MemoryCacheProvider {
 	/// Serial queue for provide thread-safe operations
 	internal let queue = dispatch_queue_create("com.RxHttpClient.MemoryCacheProvider.SerialQueue", DISPATCH_QUEUE_SERIAL)
 	
-	public init(uid: String, contentMimeType: String? = nil) {
+	public init(uid: String = NSUUID().UUIDString, contentMimeType: String? = nil) {
 		self.uid = uid
 		self.contentMimeType = contentMimeType
+	}
+	
+	public convenience init(contentMimeType: String) {
+		self.init(uid: NSUUID().UUIDString, contentMimeType: contentMimeType)
 	}
 	
 	/**

--- a/RxHttpClient/NSURLSessionDataEventsObserver.swift
+++ b/RxHttpClient/NSURLSessionDataEventsObserver.swift
@@ -6,6 +6,7 @@ enum SessionDataEvents {
 		completion: (NSURLSessionResponseDisposition) -> Void)
 	case didReceiveData(session: NSURLSessionType, dataTask: NSURLSessionDataTaskType, data: NSData)
 	case didCompleteWithError(session: NSURLSessionType, dataTask: NSURLSessionTaskType, error: NSError?)
+	case didBecomeInvalidWithError(session: NSURLSessionType, error: NSError?)
 }
 
 protocol NSURLSessionDataEventsObserverType {
@@ -18,20 +19,26 @@ extension NSURLSessionDataEventsObserver : NSURLSessionDataEventsObserverType {
 	}
 }
 
-final class NSURLSessionDataEventsObserver : NSObject, NSURLSessionDataDelegate {
+final class NSURLSessionDataEventsObserver : NSObject {
 	internal let sessionEventsSubject = PublishSubject<SessionDataEvents>()
 }
 
-extension NSURLSessionDataEventsObserver {
+extension NSURLSessionDataEventsObserver : NSURLSessionDataDelegate {
 	func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveResponse response: NSURLResponse,
-		completionHandler: (NSURLSessionResponseDisposition) -> Void) {
-			sessionEventsSubject.onNext(.didReceiveResponse(session: session, dataTask: dataTask, response: response, completion: completionHandler))
+	                completionHandler: (NSURLSessionResponseDisposition) -> Void) {
+		sessionEventsSubject.onNext(.didReceiveResponse(session: session, dataTask: dataTask, response: response, completion: completionHandler))
 	}
 	
 	func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveData data: NSData) {
 		sessionEventsSubject.onNext(.didReceiveData(session: session, dataTask: dataTask, data: data))
 	}
-	
+}
+extension NSURLSessionDataEventsObserver : NSURLSessionDelegate {
+	func URLSession(session: NSURLSession, didBecomeInvalidWithError error: NSError?) {
+		sessionEventsSubject.onNext(.didBecomeInvalidWithError(session: session, error: error))
+	}
+}
+extension NSURLSessionDataEventsObserver : NSURLSessionTaskDelegate {
 	func URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError error: NSError?) {
 		sessionEventsSubject.onNext(.didCompleteWithError(session: session, dataTask: task, error: error))
 	}

--- a/RxHttpClientTests/HttpClientBasicTests.swift
+++ b/RxHttpClientTests/HttpClientBasicTests.swift
@@ -64,7 +64,7 @@ class HttpClientBasicTests: XCTestCase {
 		}
 		
 		let client = HttpClient()
-		let request = (URL: NSURL(baseUrl: "https://test.com/json", parameters: nil)!)
+		let request = NSURLRequest(URL: NSURL(baseUrl: "https://test.com/json", parameters: nil)!)
 		let bag = DisposeBag()
 		
 		let expectation = expectationWithDescription("Should return correct data")
@@ -172,7 +172,7 @@ class HttpClientBasicTests: XCTestCase {
 		
 		let expectation = expectationWithDescription("Should return error")
 		client.loadData(request).doOnError { error in
-			guard case let HttpRequestError.Unsuccessful(response as NSHTTPURLResponse, data) = error else {
+			guard case let HttpClientError.InvalidResponse(response, data) = error else {
 				XCTFail("Should return correct error")
 				return
 			}
@@ -270,5 +270,26 @@ class HttpClientBasicTests: XCTestCase {
 		let request = httpClient.createUrlRequest(url, headers: headers)
 		XCTAssertEqual(url, request.URL)
 		XCTAssertEqual(headers, request.allHTTPHeaderFields!)
+	}
+	
+	func testReturnCorrectErrorIfSessionInvalidatedWithError() {
+		let session = FakeSession()
+		let client = HttpClient(session: session)
+		
+		session.task = FakeDataTask(resumeClosure: { _ in
+			client.sessionObserver.sessionEventsSubject.onNext(.didBecomeInvalidWithError(session: session, error: NSError(domain: "Test", code: 123, userInfo: nil)))
+		})
+		
+		let request = (URL: NSURL(baseUrl: "https://test.com/json", parameters: nil)!)
+		let bag = DisposeBag()
+		
+		let expectation = expectationWithDescription("Should return correct error")
+		client.loadData(request).doOnError { error in
+			if case HttpClientError.SessionInvalidatedWithError(let error) = error where error.code == 123 {
+				expectation.fulfill()
+			}
+		}.subscribe().addDisposableTo(bag)
+		
+		waitForExpectationsWithTimeout(1, handler: nil)
 	}
 }

--- a/RxHttpClientTests/HttpClientBasicTests.swift
+++ b/RxHttpClientTests/HttpClientBasicTests.swift
@@ -150,8 +150,8 @@ class HttpClientBasicTests: XCTestCase {
 		let bag = DisposeBag()
 		
 		let expectation = expectationWithDescription("Should return error")
-		client.loadData(request).doOnError { error in
-			let error = error as NSError
+		client.loadData(request).doOnError { result in
+			guard case HttpClientError.ClientSideError(let error) = result else { return }
 			XCTAssertEqual(error.code, 1, "Check error code")
 			XCTAssertEqual(error.domain, "TestDomain", "Check error domain")
 			expectation.fulfill()

--- a/RxHttpClientTests/MemoryCacheProviderTests.swift
+++ b/RxHttpClientTests/MemoryCacheProviderTests.swift
@@ -90,7 +90,6 @@ class MemoryCacheProviderTests: XCTestCase {
 		let dataTask = session.dataTaskWithRequest(request)
 		let task = StreamDataTask(taskUid: NSUUID().UUIDString,
 		                          dataTask: dataTask,
-		                          httpClient: httpClient,
 		                          sessionEvents: httpClient.sessionObserver.sessionEvents,
 		                          cacheProvider: MemoryCacheProvider(uid: NSUUID().UUIDString))
 

--- a/RxHttpClientTests/MemoryCacheProviderTests.swift
+++ b/RxHttpClientTests/MemoryCacheProviderTests.swift
@@ -53,6 +53,17 @@ class MemoryCacheProviderTests: XCTestCase {
 		session = nil
 	}
 	
+	func testInitWithCorrectMimeType() {
+		let provider = MemoryCacheProvider(contentMimeType: "audio/mpeg")
+		XCTAssertEqual("audio/mpeg", provider.contentMimeType)
+	}
+	
+	func testInitWithUidAndEmptyMimeType() {
+		let provider = MemoryCacheProvider()
+		XCTAssertNil(provider.contentMimeType)
+		XCTAssertNotEqual("", provider.uid)
+	}
+	
 	func testCacheCorrectData() {
 		let taskCancelExpectation = expectationWithDescription("Should cancel task and not invalidate tession")
 		session.task = FakeDataTask(resumeClosure: resumeActions, cancelClosure: { taskCancelExpectation.fulfill() })

--- a/RxHttpClientTests/StreamDataTaskTests.swift
+++ b/RxHttpClientTests/StreamDataTaskTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import RxSwift
+import OHHTTPStubs
 @testable import RxHttpClient
 
 class StreamDataTaskTests: XCTestCase {
@@ -128,11 +129,99 @@ class StreamDataTaskTests: XCTestCase {
 		session.task = FakeDataTask(resumeClosure: { _ in})
 		let dataTask = session.dataTaskWithRequest(request)
 		let streamTask = StreamDataTask(taskUid: NSUUID().UUIDString,
-		                                dataTask: dataTask, httpClient: httpClient,
+		                                dataTask: dataTask, 
 		                                sessionEvents: httpClient.sessionObserver.sessionEvents,
 		                                cacheProvider: nil)
 
 		XCTAssertTrue(streamTask.dataTask.originalRequest === request)
 		XCTAssertNil(streamTask.cacheProvider, "Cache provider should not be specified")
+	}
+	
+	func testCheckDeinitOfHttpClientNotCancellingRunningTasks() {
+		stub({ $0.URL?.absoluteString == "https://test.com/json"	}) { _ in
+			return OHHTTPStubsResponse(data: NSData(), statusCode: 200, headers: nil).requestTime(1, responseTime: 0)
+		}
+		
+		var client: HttpClient! = HttpClient()
+		let request = NSURLRequest(URL: NSURL(baseUrl: "https://test.com/json", parameters: nil)!)
+		let bag = DisposeBag()
+		
+		let expectation = expectationWithDescription("Should complete stream task")
+		
+		// creating stream task
+		let task = client.createStreamDataTask(request, cacheProvider: nil)
+		task.taskProgress.bindNext { result in
+			if case StreamTaskEvents.Success = result {
+				expectation.fulfill()
+			}
+		}.addDisposableTo(bag)
+		
+		// resuming task
+		task.resume()
+		
+		// setting cient to nil
+		// client will invoke finishTasksAndInvalidate method on NSURLSession, so task should be completed
+		client = nil
+		waitForExpectationsWithTimeout(2, handler: nil)
+	}
+	
+	func testCheckCancellingRunningTasksIfForcellyCancelSession() {
+		stub({ $0.URL?.absoluteString == "https://test.com/json"	}) { _ in
+			return OHHTTPStubsResponse(data: NSData(), statusCode: 200, headers: nil).requestTime(1, responseTime: 0)
+		}
+		
+		let client = HttpClient()
+		let request = NSURLRequest(URL: NSURL(baseUrl: "https://test.com/json", parameters: nil)!)
+		let bag = DisposeBag()
+		
+		let expectation = expectationWithDescription("Should return cancelation error")
+		
+		// creating stream task
+		let task = client.createStreamDataTask(request, cacheProvider: nil)
+		task.taskProgress.bindNext { result in
+			print("event: \(result)")
+			if case StreamTaskEvents.Error(let error as NSError) = result where error.code == -999 {
+				expectation.fulfill()
+			}
+			}.addDisposableTo(bag)
+		
+		// resuming task
+		task.resume()
+		
+		// invoke invalidateAndCancel on session, this should immediatelly cancel task
+		(client.urlSession as! NSURLSession).invalidateAndCancel()
+		waitForExpectationsWithTimeout(2, handler: nil)
+	}
+	
+	func testCheckTaskNotStartedIfHttpClientWasDeinited() {
+		stub({ $0.URL?.absoluteString == "https://test.com/json"	}) { _ in
+			return OHHTTPStubsResponse(data: NSData(), statusCode: 200, headers: nil).requestTime(1, responseTime: 0)
+		}
+		
+		var client: HttpClient! = HttpClient()
+		let request = NSURLRequest(URL: NSURL(baseUrl: "https://test.com/json", parameters: nil)!)
+		let bag = DisposeBag()
+		
+		let expectation = expectationWithDescription("Should complete stream task")
+		
+		// creating stream task
+		let task = client.createStreamDataTask(request, cacheProvider: nil)
+		task.taskProgress.bindNext { result in
+			// checking if session was explicitly invalidated (while deinit of HttpClient)
+			if case StreamTaskEvents.Error(let error) = result, case HttpClientError.SessionExplicitlyInvalidated = error {
+				expectation.fulfill()
+			}
+			}.addDisposableTo(bag)
+		
+		// setting cient to nil before resume a task
+		client = nil
+		
+		// resuming task
+		// in this case task should not be started
+		task.resume()
+		
+		waitForExpectationsWithTimeout(2, handler: nil)
+		
+		XCTAssertFalse(task.resumed)
 	}
 }

--- a/RxHttpClientTests/StreamDataTaskTests.swift
+++ b/RxHttpClientTests/StreamDataTaskTests.swift
@@ -179,7 +179,6 @@ class StreamDataTaskTests: XCTestCase {
 		// creating stream task
 		let task = client.createStreamDataTask(request, cacheProvider: nil)
 		task.taskProgress.bindNext { result in
-			print("event: \(result)")
 			if case StreamTaskEvents.Error(let error as NSError) = result where error.code == -999 {
 				expectation.fulfill()
 			}


### PR DESCRIPTION
All custom errors now represented in HttpClientError enum.
Add first version of Readme.md.